### PR TITLE
Adding invoke_arn output to lambda module

### DIFF
--- a/docs/lambda.md
+++ b/docs/lambda.md
@@ -22,6 +22,7 @@
 
 | Name | Description |
 |------|-------------|
+| invoke_arn |  |
 | lambda_arn |  |
 | lambda_name |  |
 

--- a/docs/node.md
+++ b/docs/node.md
@@ -26,6 +26,7 @@
 
 | Name | Description |
 |------|-------------|
+| invoke_arn |  |
 | lambda_arn |  |
 | lambda_name |  |
 | s3_location |  |

--- a/docs/scala.md
+++ b/docs/scala.md
@@ -29,6 +29,7 @@
 
 | Name | Description |
 |------|-------------|
+| invoke_arn |  |
 | lambda_arn |  |
 | lambda_name |  |
 | s3_location |  |

--- a/examples/node/main.tf
+++ b/examples/node/main.tf
@@ -14,9 +14,11 @@ module "my_lambda" {
   package_prefix = "tf_versioned/builds"
   lambda_dir     = "files/hello_world"
   build_script   = "files/custom_build_docker.sh"
+
   tags = {
     MyCustomTag = "foobar"
   }
+
   env_vars = {
     MyEnvVar = "foobar"
   }

--- a/examples/us-east-1/main.tf
+++ b/examples/us-east-1/main.tf
@@ -54,8 +54,8 @@ EOF
 }
 
 resource "aws_iam_policy_attachment" "eni_perms" {
-  name = "eni_perms"
-  roles = ["${aws_iam_role.my_lambda_role.id}"]
+  name       = "eni_perms"
+  roles      = ["${aws_iam_role.my_lambda_role.id}"]
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 

--- a/modules/lambda/outputs.tf
+++ b/modules/lambda/outputs.tf
@@ -5,3 +5,7 @@ output "lambda_arn" {
 output "lambda_name" {
   value = "${element(coalescelist(aws_lambda_function.lambda.*.function_name, aws_lambda_function.lambda_vpc.*.function_name), 0)}"
 }
+
+output "invoke_arn" {
+  value = "${element(coalescelist(aws_lambda_function.lambda.*.invoke_arn, aws_lambda_function.lambda_vpc.*.invoke_arn), 0)}"
+}

--- a/modules/node/outputs.tf
+++ b/modules/node/outputs.tf
@@ -9,3 +9,7 @@ output "lambda_name" {
 output "s3_location" {
   value = "${module.build.s3_location}"
 }
+
+output "invoke_arn" {
+  value = "${module.lambda.invoke_arn}"
+}

--- a/modules/scala/outputs.tf
+++ b/modules/scala/outputs.tf
@@ -9,3 +9,7 @@ output "lambda_name" {
 output "s3_location" {
   value = "${module.build.s3_location}"
 }
+
+output "invoke_arn" {
+  value = "${module.lambda.invoke_arn}"
+}


### PR DESCRIPTION
When working with some tools like API Gateway, the lambda
module needs to have the invoke_arn, which was previously
inaccessible here. This adds it to the lambda and node modules.